### PR TITLE
Update the installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ GNU GLOBAL compatible source code tagging for golang
 ## Installation
 
 ~~~
-go get github.com/juntaki/gogtags
+go install github.com/juntaki/gogtags@latest
 ~~~
 
 ## GNU GLOBAL Installation for gogtags


### PR DESCRIPTION
Hi,

Since `'go get' is no longer supported outside a module.`, I update the instruction in README.